### PR TITLE
Add command line flags for severity

### DIFF
--- a/pylint_exit.py
+++ b/pylint_exit.py
@@ -191,11 +191,10 @@ def parse_args():
 def apply_enforcement_setting(key, value):
     """
     Apply an enforcement setting
-    Args:
-        key (str):
-        value (int):
 
-    Returns:
+    Args:
+        key (str): specific message level to set
+        value (int): new value for level
 
     """
     POSITIONS = {
@@ -205,6 +204,7 @@ def apply_enforcement_setting(key, value):
         "refactor": 3,
         "convention": 4
     }
+    # fetch the position from the dict
     position = POSITIONS[key]
 
     # unpack the tuple so it can be modified

--- a/pylint_exit.py
+++ b/pylint_exit.py
@@ -1,9 +1,10 @@
 #!/usr/local/bin/python
 from __future__ import print_function
-import sys
-from bitarray import bitarray
-import argparse
 
+import argparse
+import sys
+
+from bitarray import bitarray
 
 # Package information
 version = __version__ = "0.1.0rc1"
@@ -168,13 +169,85 @@ def test():
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser()
+
     parser.add_argument('pylint_exit_code', metavar='PYLINTRC', type=int,
-                    help='pylint return code')
+                        help='pylint return code')
+
+    parser.add_argument('-efail', '--error-fail', action='store_true',
+                        help='Fail on issued error messages')
+
+    parser.add_argument('-wfail', '--warn-fail', action='store_true',
+                        help='fail on issued warnings messages')
+
+    parser.add_argument('-rfail', '--refactor-fail', action='store_true',
+                        help='fail on issued refactor messages')
+
+    parser.add_argument('-cfail', '--convention-fail', action='store_true',
+                        help='fail on issued convention messages')
+
     return parser.parse_args()
+
+
+def apply_enforcement_setting(key, value):
+    """
+    Apply an enforcement setting
+    Args:
+        key (str):
+        value (int):
+
+    Returns:
+
+    """
+    POSITIONS = {
+        "fatal": 0,
+        "error": 1,
+        "warning": 2,
+        "refactor": 3,
+        "convention": 4
+    }
+    position = POSITIONS[key]
+
+    # unpack the tuple so it can be modified
+    encoded, description, enforce = EXIT_CODES_LIST[position]
+    enforce = value  # set the element to True (error)
+
+    # repack it back into a tuple to match existing data type
+    EXIT_CODES_LIST[position] = encoded, description, enforce
+
+
+def handle_cli_flags(namespace):
+    """
+    Applies the CLI flags
+
+    Args:
+        namespace (argparse.Namespace): namespace from CLI arguments
+
+    """
+    # [
+    #   (1, 'fatal message issued', 1),
+    #   (2, 'error message issued', 0),
+    #   (4, 'warning message issued', 0),
+    #   (8, 'refactor message issued', 0),
+    #   (16, 'convention message issued', 0),
+    #   (32, 'usage error', 1)
+    # ]
+    if namespace.error_fail:  # fail on errors
+        apply_enforcement_setting("error", 1)
+
+    if namespace.warn_fail:
+        apply_enforcement_setting("warning", 1)
+
+    if namespace.refactor_fail:
+        apply_enforcement_setting("refactor", 1)
+
+    if namespace.convention_fail:
+        # error on conventions
+        apply_enforcement_setting("convention", 1)
 
 
 def main():
     args = parse_args()
+    handle_cli_flags(args)
     exit_code = handle_exit_code(args.pylint_exit_code)
     sys.exit(exit_code)
 

--- a/pylint_exit.py
+++ b/pylint_exit.py
@@ -13,7 +13,7 @@ __summary__ = "Exit code handler for pylint command line utility."
 __uri__ = "https://github.com/jongracecox/pylint-exit"
 
 
-EXIT_CODES_LIST = [
+exit_code_list = [
     (1, 'fatal message issued', 1),
     (2, 'error message issued', 0),
     (4, 'warning message issued', 0),
@@ -41,7 +41,7 @@ def decode(value):
         >>> decode(3)
         [(1, 'fatal message issued', 1), (2, 'error message issued', 0)]
     """
-    return [x[1] for x in zip(bitarray(bin(value)[2:])[::-1], EXIT_CODES_LIST) if x[0]]
+    return [x[1] for x in zip(bitarray(bin(value)[2:])[::-1], exit_code_list) if x[0]]
 
 
 def get_messages(value):
@@ -106,7 +106,7 @@ def show_workings(value):
         12 (1100) = ['warning message issued', 'refactor message issued']
     """
     print("%s (%s) = %s" %
-          (value, bin(value)[2:], [x[1][1] for x in zip(bitarray(bin(value)[2:])[::-1], EXIT_CODES_LIST) if x[0]]))
+          (value, bin(value)[2:], [x[1][1] for x in zip(bitarray(bin(value)[2:])[::-1], exit_code_list) if x[0]]))
 
 
 def handle_exit_code(value):
@@ -208,11 +208,11 @@ def apply_enforcement_setting(key, value):
     position = POSITIONS[key]
 
     # unpack the tuple so it can be modified
-    encoded, description, enforce = EXIT_CODES_LIST[position]
+    encoded, description, enforce = exit_code_list[position]
     enforce = value  # set the element to True (error)
 
     # repack it back into a tuple to match existing data type
-    EXIT_CODES_LIST[position] = encoded, description, enforce
+    exit_code_list[position] = encoded, description, enforce
 
 
 def handle_cli_flags(namespace):


### PR DESCRIPTION
This PR adds a set of command-line flags that enable specifying what message types to fail on.

Presently, to change the message types to fail on( Error, warning, refactor, etc), one would either need to modify pylint-exit's source code or write a wrapper library that overwrites the `EXIT_CODE_LIST` constant.

I found the requirement of writing a wrapper and/or modifying the source file to be inflexible, as such I sought out an alternate solution.

This pull request provides the following cli flags that modify this list, thereby allowing `pylint-exit`'s behavior to be modified from the command line. 


| aliases | severity |
| --- | --- |
|`-wfail`, `--warn-fail`| Fail if a warning level message is emitted |
|`-efail`, `--error-fail`| Fail if an Error level message is emitted | 
| `-rfail`, `--refactor-fail` | Fail if a Refactor level message is emitted |
|`-cfail`, `--convention-fail` | Fail if a convention level message is emitted |

- If the flag is present, it will be used instead of the value from the source file.
- If the flag is not present, the value from the source file will be used instead.
This is done as not to change the existing interface.


These flags allow users to specify what message types they want to fail on from a shell script / command line, rather than having to rely on forking this project and making source changes.

Example usage:
```bash
pylint-exit> python .\pylint_exit.py 24 -cfail
The following messages were raised:

  - refactor message issued
  - convention message issued

Fatal messages detected.  Failing...
```


