### PR TITLE
Remove bitarray dependency (fixes issue #5)

### DIFF
--- a/pylint_exit.py
+++ b/pylint_exit.py
@@ -4,8 +4,6 @@ from __future__ import print_function
 import argparse
 import sys
 
-from bitarray import bitarray
-
 # Package information
 version = __version__ = "1.1.0"
 __title__ = "pylint_exit"
@@ -42,7 +40,7 @@ def decode(value):
         >>> decode(3)
         [(1, 'fatal message issued', 1), (2, 'error message issued', 0)]
     """
-    return [x[1] for x in zip(bitarray(bin(value)[2:])[::-1], exit_code_list) if x[0]]
+    return [x[1] for x in zip(format(value, "b")[::-1], exit_code_list) if int(x[0])]
 
 
 def get_messages(value):
@@ -106,8 +104,7 @@ def show_workings(value):
         >>> show_workings(12)
         12 (1100) = ['warning message issued', 'refactor message issued']
     """
-    print("%s (%s) = %s" %
-          (value, bin(value)[2:], [x[1][1] for x in zip(bitarray(bin(value)[2:])[::-1], exit_code_list) if x[0]]))
+    print("{0} ({0:b}) = {1}".format(value, [y[1] for y in decode(value)]))
 
 
 def handle_exit_code(value):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-bitarray

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     py_modules=['pylint_exit'],
     setup_requires=['setuptools', 'wheel', 'm2r'],
     tests_require=[],
-    install_requires=['bitarray'],
+    install_requires=[],
     data_files=[],
     options={
         'bdist_wheel': {'universal': True}


### PR DESCRIPTION
This pull request fixes issue #5 by removing bitarray dependency.

No replacement library is required, as the (only) used bitarray functionality can be done using Python's truthiness logic, namely that `0` is `falsy`. I also took the liberty to use built-in [`format()`](https://docs.python.org/3.8/library/functions.html#format) function so that the initial conversion from `value` to its binary representation is a bit more clear for humans reading the code.