### PR TITLE
Remove m2r dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author='Jon Grace-Cox',
     author_email='jongracecox@gmail.com',
     py_modules=['pylint_exit'],
-    setup_requires=['setuptools', 'wheel', 'm2r'],
+    setup_requires=['setuptools', 'wheel'],
     tests_require=[],
     install_requires=[],
     data_files=[],


### PR DESCRIPTION
Hi there,

I'm currently packaging the `pylint-exit` package for NixOS/nixpkgs and in the process I noticed that the setup requirement `m2r` is not used at all. 
Am I missing something here? If not, this PR removes the dependency. 

Best, Fabian